### PR TITLE
Change DB port to 3307

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # java-spring-rest-api-park
+
+By default, the MySQL container is bound to port 3307 on the host.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_USER: user
       MYSQL_PASSWORD: password
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - db_data:/var/lib/mysql
 


### PR DESCRIPTION
## Summary
- change MySQL host port mapping to 3307 in docker-compose
- document new port in README

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch...)*

------
https://chatgpt.com/codex/tasks/task_e_687eca013aec832cb118c49842687d6a